### PR TITLE
Fix so exit-code works properly

### DIFF
--- a/lib/CometDeployer.js
+++ b/lib/CometDeployer.js
@@ -33,7 +33,7 @@ class CometDeployer {
     }
 
     injectErrorHandler(shipit) {
-        shipit.on('task_error', this.exitWithError);
+        shipit.on('task_err', this.exitWithError);
     }
 
     configureShipit(shipit, config) {

--- a/spec/lib/CometDeployerSpec.js
+++ b/spec/lib/CometDeployerSpec.js
@@ -55,7 +55,7 @@ describe('CometDeployer', () => {
 
     it('should configure error handler', function () {
       cometDeployer.injectErrorHandler(shipit);
-      expect(shipit.on).toHaveBeenCalledWith('task_error', cometDeployer.exitWithError);
+      expect(shipit.on).toHaveBeenCalledWith('task_err', cometDeployer.exitWithError);
     });
 
     it('should exit on error event', function () {


### PR DESCRIPTION
Wrong event-name for handling task-errors caused process exit to never be triggered.
